### PR TITLE
[#2] fix: Add EditExpenseScreen - resolve missing edit route crash

### DIFF
--- a/frontend/src/navigation/GroupsNavigator.tsx
+++ b/frontend/src/navigation/GroupsNavigator.tsx
@@ -5,6 +5,7 @@ import { GroupDetailScreen } from '@screens/groups/GroupDetailScreen';
 import { CreateGroupScreen } from '@screens/groups/CreateGroupScreen';
 import { AddExpenseScreen } from '@screens/expenses/AddExpenseScreen';
 import { ExpenseDetailScreen } from '@screens/expenses/ExpenseDetailScreen';
+import { EditExpenseScreen } from '@screens/expenses/EditExpenseScreen';
 import { BalancesScreen } from '@screens/settlements/BalancesScreen';
 import { SettleUpScreen } from '@screens/settlements/SettleUpScreen';
 import type { GroupsStackParamList } from '@types';
@@ -38,6 +39,11 @@ export const GroupsNavigator = () => {
                 name="ExpenseDetail"
                 component={ExpenseDetailScreen}
                 options={{ title: 'Expense Details' }}
+            />
+            <Stack.Screen
+                name="EditExpense"
+                component={EditExpenseScreen}
+                options={{ title: 'Edit Expense', presentation: 'modal' }}
             />
             <Stack.Screen
                 name="Balances"

--- a/frontend/src/navigation/GroupsNavigator.tsx
+++ b/frontend/src/navigation/GroupsNavigator.tsx
@@ -4,6 +4,9 @@ import { GroupListScreen } from '@screens/groups/GroupListScreen';
 import { GroupDetailScreen } from '@screens/groups/GroupDetailScreen';
 import { CreateGroupScreen } from '@screens/groups/CreateGroupScreen';
 import { AddExpenseScreen } from '@screens/expenses/AddExpenseScreen';
+import { ExpenseDetailScreen } from '@screens/expenses/ExpenseDetailScreen';
+import { BalancesScreen } from '@screens/settlements/BalancesScreen';
+import { SettleUpScreen } from '@screens/settlements/SettleUpScreen';
 import type { GroupsStackParamList } from '@types';
 
 const Stack = createStackNavigator<GroupsStackParamList>();
@@ -19,7 +22,7 @@ export const GroupsNavigator = () => {
             <Stack.Screen
                 name="GroupDetail"
                 component={GroupDetailScreen}
-                options={{ title: 'Group Details' }}
+                options={({ route }: any) => ({ title: route.params?.groupName || 'Group' })}
             />
             <Stack.Screen
                 name="CreateGroup"
@@ -30,6 +33,21 @@ export const GroupsNavigator = () => {
                 name="AddExpense"
                 component={AddExpenseScreen}
                 options={{ title: 'Add Expense', presentation: 'modal' }}
+            />
+            <Stack.Screen
+                name="ExpenseDetail"
+                component={ExpenseDetailScreen}
+                options={{ title: 'Expense Details' }}
+            />
+            <Stack.Screen
+                name="Balances"
+                component={BalancesScreen}
+                options={{ title: 'Balances & Settlements' }}
+            />
+            <Stack.Screen
+                name="SettleUp"
+                component={SettleUpScreen}
+                options={{ title: 'Settle Up', presentation: 'modal' }}
             />
         </Stack.Navigator>
     );

--- a/frontend/src/screens/expenses/AddExpenseScreen.tsx
+++ b/frontend/src/screens/expenses/AddExpenseScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useCallback } from 'react';
 import {
     View,
     StyleSheet,
@@ -15,17 +15,25 @@ import {
     Chip,
     SegmentedButtons,
     RadioButton,
+    Checkbox,
+    Card,
+    Divider,
 } from 'react-native-paper';
-import { useForm, Controller, useFieldArray } from 'react-hook-form';
+import { useForm, Controller } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
 import { useCreateExpenseMutation } from '@api/expensesApi';
 import { useGetGroupsQuery } from '@api/groupsApi';
+import { useAppSelector } from '@hooks/redux';
 import { spacing } from '@theme';
-import type { ExpenseFormData } from '@types';
 
 const CATEGORIES = [
-    'food', 'transport', 'entertainment', 'utilities', 'shopping', 'other'
+    { label: '🍔 Food', value: 'food' },
+    { label: '🚗 Transport', value: 'transport' },
+    { label: '🎬 Fun', value: 'entertainment' },
+    { label: '💡 Utilities', value: 'utilities' },
+    { label: '🛍️ Shopping', value: 'shopping' },
+    { label: '📦 Other', value: 'other' },
 ];
 
 const SPLIT_TYPES = [
@@ -35,30 +43,30 @@ const SPLIT_TYPES = [
     { value: 'shares', label: 'Shares' },
 ];
 
-const createExpenseSchema = z.object({
+const schema = z.object({
     groupId: z.string().min(1, 'Select a group'),
     description: z.string().min(1, 'Description required').max(255),
     amount: z.number().min(0.01, 'Amount must be positive'),
     currency: z.string().length(3),
-    date: z.date(),
     category: z.string().optional(),
     notes: z.string().optional(),
     payerId: z.string().min(1, 'Select who paid'),
     splitType: z.enum(['equal', 'exact', 'percentage', 'shares']),
-    splits: z.array(z.object({
-        userId: z.string(),
-        amount: z.number().optional(),
-        percentage: z.number().optional(),
-        shares: z.number().optional(),
-    })).min(1),
 });
+
+type FormData = z.infer<typeof schema>;
 
 export const AddExpenseScreen = ({ navigation, route }: any) => {
     const theme = useTheme();
+    const currentUser = useAppSelector((state: any) => state.auth.user);
     const [createExpense, { isLoading }] = useCreateExpenseMutation();
     const { data: groupsData } = useGetGroupsQuery();
     const [error, setError] = useState('');
     const [success, setSuccess] = useState(false);
+
+    // Member selection & split values
+    const [selectedMembers, setSelectedMembers] = useState<string[]>([]);
+    const [splitValues, setSplitValues] = useState<Record<string, string>>({});
 
     const {
         control,
@@ -66,19 +74,17 @@ export const AddExpenseScreen = ({ navigation, route }: any) => {
         formState: { errors },
         watch,
         setValue,
-    } = useForm<ExpenseFormData>({
-        resolver: zodResolver(createExpenseSchema),
+    } = useForm<FormData>({
+        resolver: zodResolver(schema),
         defaultValues: {
             groupId: route.params?.groupId || '',
             description: '',
             amount: 0,
             currency: 'USD',
-            date: new Date(),
             category: 'other',
             notes: '',
-            payerId: '',
+            payerId: currentUser?.id || '',
             splitType: 'equal',
-            splits: [],
         },
     });
 
@@ -86,24 +92,96 @@ export const AddExpenseScreen = ({ navigation, route }: any) => {
     const selectedGroupId = watch('groupId');
     const amount = watch('amount');
 
-    // Get members from selected group
     const groupMembers = React.useMemo(() => {
         if (!groupsData?.groups || !selectedGroupId) return [];
         const group = groupsData.groups.find((g: any) => g.id === selectedGroupId);
         return group?.members || [];
     }, [groupsData, selectedGroupId]);
 
-    const onSubmit = async (data: ExpenseFormData) => {
+    // Auto-select all members when group changes
+    React.useEffect(() => {
+        if (groupMembers.length > 0) {
+            setSelectedMembers(groupMembers.map((m: any) => m.userId));
+        }
+    }, [groupMembers.length]);
+
+    const toggleMember = useCallback((userId: string) => {
+        setSelectedMembers((prev) =>
+            prev.includes(userId) ? prev.filter((id) => id !== userId) : [...prev, userId]
+        );
+    }, []);
+
+    // Compute per-member preview amounts
+    const splitPreview = React.useMemo(() => {
+        if (!amount || selectedMembers.length === 0) return {};
+        const preview: Record<string, number> = {};
+
+        if (splitType === 'equal') {
+            const share = amount / selectedMembers.length;
+            selectedMembers.forEach((id) => { preview[id] = share; });
+        } else if (splitType === 'exact') {
+            selectedMembers.forEach((id) => {
+                preview[id] = parseFloat(splitValues[id] || '0');
+            });
+        } else if (splitType === 'percentage') {
+            selectedMembers.forEach((id) => {
+                const pct = parseFloat(splitValues[id] || '0');
+                preview[id] = (amount * pct) / 100;
+            });
+        } else if (splitType === 'shares') {
+            const totalShares = selectedMembers.reduce(
+                (sum, id) => sum + parseFloat(splitValues[id] || '1'), 0
+            );
+            selectedMembers.forEach((id) => {
+                const shares = parseFloat(splitValues[id] || '1');
+                preview[id] = (amount * shares) / totalShares;
+            });
+        }
+        return preview;
+    }, [amount, splitType, selectedMembers, splitValues]);
+
+    // Validation: for non-equal splits, check sum
+    const splitValidationError = React.useMemo(() => {
+        if (splitType === 'equal' || !amount) return '';
+        const total = Object.values(splitPreview).reduce((a, b) => a + b, 0);
+        if (splitType === 'percentage') {
+            const pctSum = selectedMembers.reduce(
+                (s, id) => s + parseFloat(splitValues[id] || '0'), 0
+            );
+            if (Math.abs(pctSum - 100) > 0.01) return `Percentages must sum to 100% (currently ${pctSum.toFixed(1)}%)`;
+        } else if (splitType === 'exact') {
+            if (Math.abs(total - amount) > 0.01) return `Amounts must sum to $${amount.toFixed(2)} (currently $${total.toFixed(2)})`;
+        }
+        return '';
+    }, [splitType, splitPreview, amount, selectedMembers, splitValues]);
+
+    const buildSplits = () => {
+        return selectedMembers.map((userId) => {
+            if (splitType === 'equal') return { userId };
+            if (splitType === 'exact') return { userId, amount: parseFloat(splitValues[userId] || '0') };
+            if (splitType === 'percentage') return { userId, percentage: parseFloat(splitValues[userId] || '0') };
+            if (splitType === 'shares') return { userId, shares: parseFloat(splitValues[userId] || '1') };
+            return { userId };
+        });
+    };
+
+    const onSubmit = async (data: FormData) => {
+        if (selectedMembers.length === 0) {
+            setError('Select at least one member to split with');
+            return;
+        }
+        if (splitValidationError) {
+            setError(splitValidationError);
+            return;
+        }
         try {
             setError('');
             await createExpense({
                 ...data,
-                date: data.date.toISOString(),
+                splits: buildSplits(),
             }).unwrap();
             setSuccess(true);
-            setTimeout(() => {
-                navigation.goBack();
-            }, 1500);
+            setTimeout(() => navigation.goBack(), 1500);
         } catch (err: any) {
             setError(err?.data?.error?.message || 'Failed to create expense');
         }
@@ -112,32 +190,34 @@ export const AddExpenseScreen = ({ navigation, route }: any) => {
     return (
         <KeyboardAvoidingView
             behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
-            style={styles.container}
+            style={[styles.container, { backgroundColor: theme.colors.background }]}
         >
             <ScrollView
                 contentContainerStyle={styles.scrollContent}
                 keyboardShouldPersistTaps="handled"
             >
                 {/* Group Selection */}
-                <Controller
-                    control={control}
-                    name="groupId"
-                    render={({ field: { value, onChange } }) => (
-                        <View style={styles.section}>
-                            <Text variant="titleMedium" style={styles.label}>Group *</Text>
-                            <RadioButton.Group onValueChange={onChange} value={value}>
-                                {groupsData?.groups?.map((group: any) => (
-                                    <RadioButton.Item
-                                        key={group.id}
-                                        label={group.name}
-                                        value={group.id}
-                                    />
-                                ))}
-                            </RadioButton.Group>
-                            {errors.groupId && <Text style={styles.errorText}>{errors.groupId.message}</Text>}
-                        </View>
-                    )}
-                />
+                {!route.params?.groupId && (
+                    <Controller
+                        control={control}
+                        name="groupId"
+                        render={({ field: { value, onChange } }) => (
+                            <View style={styles.section}>
+                                <Text variant="titleMedium" style={styles.label}>Group *</Text>
+                                <RadioButton.Group onValueChange={onChange} value={value}>
+                                    {groupsData?.groups?.map((group: any) => (
+                                        <RadioButton.Item
+                                            key={group.id}
+                                            label={group.name}
+                                            value={group.id}
+                                        />
+                                    ))}
+                                </RadioButton.Group>
+                                {errors.groupId && <Text style={styles.errorText}>{errors.groupId.message}</Text>}
+                            </View>
+                        )}
+                    />
+                )}
 
                 {/* Description */}
                 <Controller
@@ -188,17 +268,20 @@ export const AddExpenseScreen = ({ navigation, route }: any) => {
                         <View style={styles.chipContainer}>
                             {CATEGORIES.map((cat) => (
                                 <Chip
-                                    key={cat}
-                                    selected={value === cat}
-                                    onPress={() => onChange(cat)}
+                                    key={cat.value}
+                                    selected={value === cat.value}
+                                    onPress={() => onChange(cat.value)}
                                     style={styles.chip}
+                                    compact
                                 >
-                                    {cat}
+                                    {cat.label}
                                 </Chip>
                             ))}
                         </View>
                     )}
                 />
+
+                <Divider style={styles.divider} />
 
                 {/* Who Paid */}
                 <Controller
@@ -221,6 +304,8 @@ export const AddExpenseScreen = ({ navigation, route }: any) => {
                     )}
                 />
 
+                <Divider style={styles.divider} />
+
                 {/* Split Type */}
                 <Text variant="titleMedium" style={styles.label}>Split Type *</Text>
                 <Controller
@@ -236,18 +321,83 @@ export const AddExpenseScreen = ({ navigation, route }: any) => {
                     )}
                 />
 
-                {/* Split Details - shown based on type */}
-                <View style={styles.section}>
-                    <Text variant="titleSmall" style={styles.label}>
-                        {splitType === 'equal' && 'Split equally among:'}
-                        {splitType === 'exact' && 'Enter exact amounts:'}
-                        {splitType === 'percentage' && 'Enter percentages:'}
-                        {splitType === 'shares' && 'Enter shares:'}
-                    </Text>
-                    <Text variant="bodySmall" style={{ color: theme.colors.onSurfaceVariant }}>
-                        Select members who will split this expense
-                    </Text>
-                </View>
+                {/* Member Split UI */}
+                {groupMembers.length > 0 && (
+                    <Card style={styles.splitCard}>
+                        <Card.Content>
+                            <Text variant="titleSmall" style={styles.label}>
+                                {splitType === 'equal' && 'Split equally among:'}
+                                {splitType === 'exact' && 'Enter exact amounts:'}
+                                {splitType === 'percentage' && 'Enter percentages (must total 100%):'}
+                                {splitType === 'shares' && 'Enter shares (ratio-based):'}
+                            </Text>
+
+                            {groupMembers.map((member: any) => {
+                                const userId = member.userId;
+                                const isSelected = selectedMembers.includes(userId);
+                                const preview = splitPreview[userId];
+
+                                return (
+                                    <View key={userId} style={styles.memberRow}>
+                                        <Checkbox
+                                            status={isSelected ? 'checked' : 'unchecked'}
+                                            onPress={() => toggleMember(userId)}
+                                        />
+                                        <Text
+                                            variant="bodyMedium"
+                                            style={[styles.memberName, !isSelected && { opacity: 0.4 }]}
+                                        >
+                                            {member.user?.name || 'Unknown'}
+                                        </Text>
+
+                                        {isSelected && splitType !== 'equal' && (
+                                            <TextInput
+                                                mode="outlined"
+                                                dense
+                                                value={splitValues[userId] || ''}
+                                                onChangeText={(v) =>
+                                                    setSplitValues((prev) => ({ ...prev, [userId]: v }))
+                                                }
+                                                keyboardType="decimal-pad"
+                                                right={
+                                                    splitType === 'percentage'
+                                                        ? <TextInput.Affix text="%" />
+                                                        : splitType === 'shares'
+                                                            ? <TextInput.Affix text="shares" />
+                                                            : <TextInput.Affix text="$" />
+                                                }
+                                                style={styles.splitInput}
+                                                placeholder={splitType === 'shares' ? '1' : '0'}
+                                            />
+                                        )}
+
+                                        {isSelected && preview !== undefined && (
+                                            <Text
+                                                variant="bodySmall"
+                                                style={[styles.previewAmount, { color: theme.colors.primary }]}
+                                            >
+                                                ${preview.toFixed(2)}
+                                            </Text>
+                                        )}
+                                    </View>
+                                );
+                            })}
+
+                            {splitValidationError ? (
+                                <Text style={[styles.errorText, { marginTop: spacing.sm }]}>
+                                    ⚠️ {splitValidationError}
+                                </Text>
+                            ) : splitType === 'equal' && selectedMembers.length > 0 && amount > 0 ? (
+                                <Text
+                                    variant="bodySmall"
+                                    style={{ color: theme.colors.primary, marginTop: spacing.sm }}
+                                >
+                                    ${(amount / selectedMembers.length).toFixed(2)} each
+                                </Text>
+                            ) : null}
+                        </Card.Content>
+                    </Card>
+                )}
 
                 {/* Notes */}
                 <Controller
@@ -257,12 +407,11 @@ export const AddExpenseScreen = ({ navigation, route }: any) => {
                         <TextInput
                             mode="outlined"
                             label="Notes (optional)"
-                            placeholder="Add any notes..."
                             value={value}
                             onChangeText={onChange}
                             onBlur={onBlur}
                             multiline
-                            numberOfLines={3}
+                            numberOfLines={2}
                             style={styles.input}
                         />
                     )}
@@ -272,8 +421,9 @@ export const AddExpenseScreen = ({ navigation, route }: any) => {
                     mode="contained"
                     onPress={handleSubmit(onSubmit)}
                     loading={isLoading}
-                    disabled={isLoading}
+                    disabled={isLoading || !!splitValidationError}
                     style={styles.submitButton}
+                    icon="check"
                 >
                     {isLoading ? 'Creating...' : 'Create Expense'}
                 </Button>
@@ -282,60 +432,43 @@ export const AddExpenseScreen = ({ navigation, route }: any) => {
             <Snackbar
                 visible={!!error}
                 onDismiss={() => setError('')}
-                duration={3000}
-                action={{ label: 'Dismiss', onPress: () => setError('') }}
+                duration={4000}
+                action={{ label: 'OK', onPress: () => setError('') }}
             >
                 {error}
             </Snackbar>
-
-            <Snackbar
-                visible={success}
-                onDismiss={() => setSuccess(false)}
-                duration={1500}
-            >
-                Expense created successfully!
+            <Snackbar visible={success} onDismiss={() => setSuccess(false)} duration={1500}>
+                ✅ Expense created!
             </Snackbar>
         </KeyboardAvoidingView>
     );
 };
 
 const styles = StyleSheet.create({
-    container: {
-        flex: 1,
-    },
-    scrollContent: {
-        padding: spacing.lg,
-    },
-    section: {
-        marginBottom: spacing.md,
-    },
-    input: {
-        marginBottom: spacing.sm,
-    },
-    label: {
-        marginTop: spacing.sm,
-        marginBottom: spacing.sm,
-    },
+    container: { flex: 1 },
+    scrollContent: { padding: spacing.lg, paddingBottom: spacing.xl * 2 },
+    section: { marginBottom: spacing.md },
+    input: { marginBottom: spacing.sm },
+    label: { marginTop: spacing.sm, marginBottom: spacing.sm, fontWeight: '600' },
     chipContainer: {
         flexDirection: 'row',
         flexWrap: 'wrap',
         gap: spacing.sm,
         marginBottom: spacing.md,
     },
-    chip: {
-        marginRight: spacing.sm,
-        marginBottom: spacing.sm,
+    chip: { marginRight: spacing.xs, marginBottom: spacing.xs },
+    segmented: { marginBottom: spacing.md },
+    divider: { marginVertical: spacing.md },
+    splitCard: { marginBottom: spacing.md },
+    memberRow: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        paddingVertical: spacing.xs,
+        gap: spacing.sm,
     },
-    segmented: {
-        marginBottom: spacing.md,
-    },
-    errorText: {
-        color: '#F44336',
-        fontSize: 12,
-        marginBottom: spacing.sm,
-        marginLeft: spacing.sm,
-    },
-    submitButton: {
-        marginTop: spacing.xl,
-    },
+    memberName: { flex: 1 },
+    splitInput: { width: 100 },
+    previewAmount: { minWidth: 60, textAlign: 'right', fontWeight: '600' },
+    errorText: { color: '#F44336', fontSize: 12, marginBottom: spacing.sm },
+    submitButton: { marginTop: spacing.lg },
 });

--- a/frontend/src/screens/expenses/EditExpenseScreen.tsx
+++ b/frontend/src/screens/expenses/EditExpenseScreen.tsx
@@ -1,0 +1,512 @@
+import React, { useState, useCallback, useEffect } from 'react';
+import {
+    View,
+    StyleSheet,
+    ScrollView,
+    KeyboardAvoidingView,
+    Platform,
+} from 'react-native';
+import {
+    Text,
+    TextInput,
+    Button,
+    useTheme,
+    Snackbar,
+    Chip,
+    SegmentedButtons,
+    RadioButton,
+    Checkbox,
+    Card,
+    Divider,
+    ActivityIndicator,
+} from 'react-native-paper';
+import { useForm, Controller } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { useGetExpenseQuery, useUpdateExpenseMutation } from '@api/expensesApi';
+import { useGetGroupsQuery } from '@api/groupsApi';
+import { spacing } from '@theme';
+
+const CATEGORIES = [
+    { label: '🍔 Food', value: 'food' },
+    { label: '🚗 Transport', value: 'transport' },
+    { label: '🎬 Fun', value: 'entertainment' },
+    { label: '💡 Utilities', value: 'utilities' },
+    { label: '🛍️ Shopping', value: 'shopping' },
+    { label: '📦 Other', value: 'other' },
+];
+
+const SPLIT_TYPES = [
+    { value: 'equal', label: 'Equal' },
+    { value: 'exact', label: 'Exact' },
+    { value: 'percentage', label: '%' },
+    { value: 'shares', label: 'Shares' },
+];
+
+const schema = z.object({
+    description: z.string().min(1, 'Description required').max(255),
+    amount: z.number().min(0.01, 'Amount must be positive'),
+    currency: z.string().length(3),
+    category: z.string().optional(),
+    notes: z.string().optional(),
+    payerId: z.string().min(1, 'Select who paid'),
+    splitType: z.enum(['equal', 'exact', 'percentage', 'shares']),
+});
+
+type FormData = z.infer<typeof schema>;
+
+export const EditExpenseScreen = ({ navigation, route }: any) => {
+    const { expenseId } = route.params;
+    const theme = useTheme();
+
+    const { data, isLoading: loadingExpense } = useGetExpenseQuery(expenseId);
+    const [updateExpense, { isLoading: updating }] = useUpdateExpenseMutation();
+    const { data: groupsData } = useGetGroupsQuery();
+
+    const [error, setError] = useState('');
+    const [success, setSuccess] = useState(false);
+    const [initialized, setInitialized] = useState(false);
+
+    // Member selection & split values (mirroring AddExpenseScreen)
+    const [selectedMembers, setSelectedMembers] = useState<string[]>([]);
+    const [splitValues, setSplitValues] = useState<Record<string, string>>({});
+
+    const expense = data?.expense;
+
+    const {
+        control,
+        handleSubmit,
+        formState: { errors },
+        watch,
+        reset,
+    } = useForm<FormData>({
+        resolver: zodResolver(schema),
+        defaultValues: {
+            description: '',
+            amount: 0,
+            currency: 'USD',
+            category: 'other',
+            notes: '',
+            payerId: '',
+            splitType: 'equal',
+        },
+    });
+
+    // Pre-populate form once expense data loads
+    useEffect(() => {
+        if (expense && !initialized) {
+            reset({
+                description: expense.description || '',
+                amount: parseFloat(expense.amount) || 0,
+                currency: expense.currency || 'USD',
+                category: expense.category || 'other',
+                notes: expense.notes || '',
+                payerId: expense.payerId || '',
+                splitType: expense.splitType || 'equal',
+            });
+
+            // Pre-populate splits
+            if (expense.splits && expense.splits.length > 0) {
+                const memberIds = expense.splits.map((s: any) => s.userId);
+                setSelectedMembers(memberIds);
+
+                const vals: Record<string, string> = {};
+                expense.splits.forEach((s: any) => {
+                    if (expense.splitType === 'exact') vals[s.userId] = s.amount?.toString() || '';
+                    else if (expense.splitType === 'percentage') vals[s.userId] = s.percentage?.toString() || '';
+                    else if (expense.splitType === 'shares') vals[s.userId] = s.shares?.toString() || '';
+                });
+                setSplitValues(vals);
+            }
+
+            setInitialized(true);
+        }
+    }, [expense, initialized, reset]);
+
+    const splitType = watch('splitType');
+    const amount = watch('amount');
+
+    // Get group members from the expense's group
+    const groupMembers = React.useMemo(() => {
+        if (!groupsData?.groups || !expense?.groupId) return [];
+        const group = groupsData.groups.find((g: any) => g.id === expense.groupId);
+        return group?.members || [];
+    }, [groupsData, expense?.groupId]);
+
+    const toggleMember = useCallback((userId: string) => {
+        setSelectedMembers((prev) =>
+            prev.includes(userId) ? prev.filter((id) => id !== userId) : [...prev, userId]
+        );
+    }, []);
+
+    // Real-time split preview
+    const splitPreview = React.useMemo(() => {
+        if (!amount || selectedMembers.length === 0) return {};
+        const preview: Record<string, number> = {};
+
+        if (splitType === 'equal') {
+            const share = amount / selectedMembers.length;
+            selectedMembers.forEach((id) => { preview[id] = share; });
+        } else if (splitType === 'exact') {
+            selectedMembers.forEach((id) => {
+                preview[id] = parseFloat(splitValues[id] || '0');
+            });
+        } else if (splitType === 'percentage') {
+            selectedMembers.forEach((id) => {
+                preview[id] = (amount * parseFloat(splitValues[id] || '0')) / 100;
+            });
+        } else if (splitType === 'shares') {
+            const totalShares = selectedMembers.reduce(
+                (sum, id) => sum + parseFloat(splitValues[id] || '1'), 0
+            );
+            selectedMembers.forEach((id) => {
+                preview[id] = (amount * parseFloat(splitValues[id] || '1')) / totalShares;
+            });
+        }
+        return preview;
+    }, [amount, splitType, selectedMembers, splitValues]);
+
+    // Validation
+    const splitValidationError = React.useMemo(() => {
+        if (splitType === 'equal' || !amount) return '';
+        if (splitType === 'percentage') {
+            const pctSum = selectedMembers.reduce(
+                (s, id) => s + parseFloat(splitValues[id] || '0'), 0
+            );
+            if (Math.abs(pctSum - 100) > 0.01)
+                return `Percentages must sum to 100% (currently ${pctSum.toFixed(1)}%)`;
+        } else if (splitType === 'exact') {
+            const total = Object.values(splitPreview).reduce((a, b) => a + b, 0);
+            if (Math.abs(total - amount) > 0.01)
+                return `Amounts must sum to $${amount.toFixed(2)} (currently $${total.toFixed(2)})`;
+        }
+        return '';
+    }, [splitType, splitPreview, amount, selectedMembers, splitValues]);
+
+    const buildSplits = () =>
+        selectedMembers.map((userId) => {
+            if (splitType === 'equal') return { userId };
+            if (splitType === 'exact') return { userId, amount: parseFloat(splitValues[userId] || '0') };
+            if (splitType === 'percentage') return { userId, percentage: parseFloat(splitValues[userId] || '0') };
+            return { userId, shares: parseFloat(splitValues[userId] || '1') };
+        });
+
+    const onSubmit = async (data: FormData) => {
+        if (selectedMembers.length === 0) {
+            setError('Select at least one member to split with');
+            return;
+        }
+        if (splitValidationError) {
+            setError(splitValidationError);
+            return;
+        }
+        try {
+            setError('');
+            await updateExpense({
+                expenseId,
+                data: { ...data, splits: buildSplits() },
+            }).unwrap();
+            setSuccess(true);
+            setTimeout(() => navigation.goBack(), 1500);
+        } catch (err: any) {
+            setError(err?.data?.error?.message || 'Failed to update expense');
+        }
+    };
+
+    if (loadingExpense || !initialized) {
+        return (
+            <View style={[styles.centered, { backgroundColor: theme.colors.background }]}>
+                <ActivityIndicator size="large" />
+                <Text variant="bodyMedium" style={{ marginTop: spacing.md }}>
+                    Loading expense...
+                </Text>
+            </View>
+        );
+    }
+
+    if (!expense) {
+        return (
+            <View style={[styles.centered, { backgroundColor: theme.colors.background }]}>
+                <Text variant="bodyLarge">Expense not found</Text>
+                <Button onPress={() => navigation.goBack()} style={{ marginTop: spacing.md }}>
+                    Go Back
+                </Button>
+            </View>
+        );
+    }
+
+    return (
+        <KeyboardAvoidingView
+            behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+            style={[styles.container, { backgroundColor: theme.colors.background }]}
+        >
+            <ScrollView
+                contentContainerStyle={styles.scrollContent}
+                keyboardShouldPersistTaps="handled"
+            >
+                {/* Description */}
+                <Controller
+                    control={control}
+                    name="description"
+                    render={({ field: { onChange, onBlur, value } }) => (
+                        <TextInput
+                            mode="outlined"
+                            label="Description *"
+                            value={value}
+                            onChangeText={onChange}
+                            onBlur={onBlur}
+                            error={!!errors.description}
+                            style={styles.input}
+                        />
+                    )}
+                />
+                {errors.description && (
+                    <Text style={styles.errorText}>{errors.description.message}</Text>
+                )}
+
+                {/* Amount */}
+                <Controller
+                    control={control}
+                    name="amount"
+                    render={({ field: { onChange, onBlur, value } }) => (
+                        <TextInput
+                            mode="outlined"
+                            label="Amount *"
+                            value={value?.toString() || ''}
+                            onChangeText={(text) => onChange(parseFloat(text) || 0)}
+                            onBlur={onBlur}
+                            error={!!errors.amount}
+                            keyboardType="decimal-pad"
+                            left={<TextInput.Affix text="$" />}
+                            style={styles.input}
+                        />
+                    )}
+                />
+                {errors.amount && (
+                    <Text style={styles.errorText}>{errors.amount.message}</Text>
+                )}
+
+                {/* Category */}
+                <Text variant="titleMedium" style={styles.label}>Category</Text>
+                <Controller
+                    control={control}
+                    name="category"
+                    render={({ field: { value, onChange } }) => (
+                        <View style={styles.chipContainer}>
+                            {CATEGORIES.map((cat) => (
+                                <Chip
+                                    key={cat.value}
+                                    selected={value === cat.value}
+                                    onPress={() => onChange(cat.value)}
+                                    style={styles.chip}
+                                    compact
+                                >
+                                    {cat.label}
+                                </Chip>
+                            ))}
+                        </View>
+                    )}
+                />
+
+                <Divider style={styles.divider} />
+
+                {/* Who Paid */}
+                <Controller
+                    control={control}
+                    name="payerId"
+                    render={({ field: { value, onChange } }) => (
+                        <View style={styles.section}>
+                            <Text variant="titleMedium" style={styles.label}>Who paid? *</Text>
+                            <RadioButton.Group onValueChange={onChange} value={value}>
+                                {groupMembers.map((member: any) => (
+                                    <RadioButton.Item
+                                        key={member.userId}
+                                        label={member.user?.name || 'Unknown'}
+                                        value={member.userId}
+                                    />
+                                ))}
+                            </RadioButton.Group>
+                            {errors.payerId && (
+                                <Text style={styles.errorText}>{errors.payerId.message}</Text>
+                            )}
+                        </View>
+                    )}
+                />
+
+                <Divider style={styles.divider} />
+
+                {/* Split Type */}
+                <Text variant="titleMedium" style={styles.label}>Split Type *</Text>
+                <Controller
+                    control={control}
+                    name="splitType"
+                    render={({ field: { value, onChange } }) => (
+                        <SegmentedButtons
+                            value={value}
+                            onValueChange={onChange}
+                            buttons={SPLIT_TYPES}
+                            style={styles.segmented}
+                        />
+                    )}
+                />
+
+                {/* Member Split UI */}
+                {groupMembers.length > 0 && (
+                    <Card style={styles.splitCard}>
+                        <Card.Content>
+                            <Text variant="titleSmall" style={styles.label}>
+                                {splitType === 'equal' && 'Split equally among:'}
+                                {splitType === 'exact' && 'Enter exact amounts:'}
+                                {splitType === 'percentage' && 'Enter percentages (must total 100%):'}
+                                {splitType === 'shares' && 'Enter shares (ratio-based):'}
+                            </Text>
+
+                            {groupMembers.map((member: any) => {
+                                const userId = member.userId;
+                                const isSelected = selectedMembers.includes(userId);
+                                const preview = splitPreview[userId];
+
+                                return (
+                                    <View key={userId} style={styles.memberRow}>
+                                        <Checkbox
+                                            status={isSelected ? 'checked' : 'unchecked'}
+                                            onPress={() => toggleMember(userId)}
+                                        />
+                                        <Text
+                                            variant="bodyMedium"
+                                            style={[styles.memberName, !isSelected && { opacity: 0.4 }]}
+                                        >
+                                            {member.user?.name || 'Unknown'}
+                                        </Text>
+
+                                        {isSelected && splitType !== 'equal' && (
+                                            <TextInput
+                                                mode="outlined"
+                                                dense
+                                                value={splitValues[userId] || ''}
+                                                onChangeText={(v) =>
+                                                    setSplitValues((prev) => ({ ...prev, [userId]: v }))
+                                                }
+                                                keyboardType="decimal-pad"
+                                                right={
+                                                    splitType === 'percentage'
+                                                        ? <TextInput.Affix text="%" />
+                                                        : splitType === 'shares'
+                                                            ? <TextInput.Affix text="sh" />
+                                                            : <TextInput.Affix text="$" />
+                                                }
+                                                style={styles.splitInput}
+                                                placeholder={splitType === 'shares' ? '1' : '0'}
+                                            />
+                                        )}
+
+                                        {isSelected && preview !== undefined && (
+                                            <Text
+                                                variant="bodySmall"
+                                                style={[styles.previewAmount, { color: theme.colors.primary }]}
+                                            >
+                                                ${preview.toFixed(2)}
+                                            </Text>
+                                        )}
+                                    </View>
+                                );
+                            })}
+
+                            {splitValidationError ? (
+                                <Text style={[styles.errorText, { marginTop: spacing.sm }]}>
+                                    ⚠️ {splitValidationError}
+                                </Text>
+                            ) : splitType === 'equal' && selectedMembers.length > 0 && amount > 0 ? (
+                                <Text
+                                    variant="bodySmall"
+                                    style={{ color: theme.colors.primary, marginTop: spacing.sm }}
+                                >
+                                    ${(amount / selectedMembers.length).toFixed(2)} each
+                                </Text>
+                            ) : null}
+                        </Card.Content>
+                    </Card>
+                )}
+
+                {/* Notes */}
+                <Controller
+                    control={control}
+                    name="notes"
+                    render={({ field: { onChange, onBlur, value } }) => (
+                        <TextInput
+                            mode="outlined"
+                            label="Notes (optional)"
+                            value={value}
+                            onChangeText={onChange}
+                            onBlur={onBlur}
+                            multiline
+                            numberOfLines={2}
+                            style={styles.input}
+                        />
+                    )}
+                />
+
+                <Button
+                    mode="contained"
+                    onPress={handleSubmit(onSubmit)}
+                    loading={updating}
+                    disabled={updating || !!splitValidationError}
+                    style={styles.submitButton}
+                    icon="content-save"
+                >
+                    {updating ? 'Saving...' : 'Save Changes'}
+                </Button>
+
+                <Button
+                    mode="text"
+                    onPress={() => navigation.goBack()}
+                    style={{ marginTop: spacing.sm }}
+                >
+                    Cancel
+                </Button>
+            </ScrollView>
+
+            <Snackbar
+                visible={!!error}
+                onDismiss={() => setError('')}
+                duration={4000}
+                action={{ label: 'OK', onPress: () => setError('') }}
+            >
+                {error}
+            </Snackbar>
+            <Snackbar visible={success} onDismiss={() => setSuccess(false)} duration={1500}>
+                ✅ Expense updated!
+            </Snackbar>
+        </KeyboardAvoidingView>
+    );
+};
+
+const styles = StyleSheet.create({
+    container: { flex: 1 },
+    centered: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+    scrollContent: { padding: spacing.lg, paddingBottom: spacing.xl * 2 },
+    section: { marginBottom: spacing.md },
+    input: { marginBottom: spacing.sm },
+    label: { marginTop: spacing.sm, marginBottom: spacing.sm, fontWeight: '600' },
+    chipContainer: {
+        flexDirection: 'row',
+        flexWrap: 'wrap',
+        gap: spacing.sm,
+        marginBottom: spacing.md,
+    },
+    chip: { marginRight: spacing.xs, marginBottom: spacing.xs },
+    segmented: { marginBottom: spacing.md },
+    divider: { marginVertical: spacing.md },
+    splitCard: { marginBottom: spacing.md },
+    memberRow: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        paddingVertical: spacing.xs,
+        gap: spacing.sm,
+    },
+    memberName: { flex: 1 },
+    splitInput: { width: 100 },
+    previewAmount: { minWidth: 60, textAlign: 'right', fontWeight: '600' },
+    errorText: { color: '#F44336', fontSize: 12, marginBottom: spacing.sm },
+    submitButton: { marginTop: spacing.lg },
+});

--- a/frontend/src/screens/expenses/ExpenseDetailScreen.tsx
+++ b/frontend/src/screens/expenses/ExpenseDetailScreen.tsx
@@ -1,0 +1,305 @@
+import React, { useState } from 'react';
+import {
+    View,
+    StyleSheet,
+    ScrollView,
+    Alert,
+} from 'react-native';
+import {
+    Text,
+    Card,
+    Button,
+    useTheme,
+    ActivityIndicator,
+    Chip,
+    Divider,
+    IconButton,
+    Menu,
+    Snackbar,
+    Avatar,
+} from 'react-native-paper';
+import { useGetExpenseQuery, useDeleteExpenseMutation } from '@api/expensesApi';
+import { spacing } from '@theme';
+import { format } from 'date-fns';
+
+const CATEGORY_ICONS: Record<string, string> = {
+    food: '🍔',
+    transport: '🚗',
+    entertainment: '🎬',
+    utilities: '💡',
+    shopping: '🛍️',
+    other: '📦',
+};
+
+export const ExpenseDetailScreen = ({ navigation, route }: any) => {
+    const { expenseId } = route.params;
+    const theme = useTheme();
+    const [menuVisible, setMenuVisible] = useState(false);
+    const [snackbar, setSnackbar] = useState('');
+
+    const { data, isLoading, isError, refetch } = useGetExpenseQuery(expenseId);
+    const [deleteExpense, { isLoading: deleting }] = useDeleteExpenseMutation();
+
+    const expense = data?.expense;
+
+    const handleDelete = () => {
+        Alert.alert(
+            'Delete Expense',
+            `Are you sure you want to delete "${expense?.description}"?`,
+            [
+                { text: 'Cancel', style: 'cancel' },
+                {
+                    text: 'Delete',
+                    style: 'destructive',
+                    onPress: async () => {
+                        try {
+                            await deleteExpense(expenseId).unwrap();
+                            navigation.goBack();
+                        } catch {
+                            setSnackbar('Failed to delete expense');
+                        }
+                    },
+                },
+            ]
+        );
+    };
+
+    React.useLayoutEffect(() => {
+        navigation.setOptions({
+            headerRight: () => (
+                <Menu
+                    visible={menuVisible}
+                    onDismiss={() => setMenuVisible(false)}
+                    anchor={
+                        <IconButton
+                            icon="dots-vertical"
+                            onPress={() => setMenuVisible(true)}
+                        />
+                    }
+                >
+                    <Menu.Item
+                        onPress={() => {
+                            setMenuVisible(false);
+                            navigation.navigate('EditExpense', { expenseId });
+                        }}
+                        title="Edit"
+                        leadingIcon="pencil"
+                    />
+                    <Menu.Item
+                        onPress={() => {
+                            setMenuVisible(false);
+                            handleDelete();
+                        }}
+                        title="Delete"
+                        leadingIcon="trash-can"
+                        titleStyle={{ color: theme.colors.error }}
+                    />
+                </Menu>
+            ),
+        });
+    }, [navigation, menuVisible, expense]);
+
+    if (isLoading) {
+        return (
+            <View style={[styles.centered, { backgroundColor: theme.colors.background }]}>
+                <ActivityIndicator size="large" />
+            </View>
+        );
+    }
+
+    if (isError || !expense) {
+        return (
+            <View style={[styles.centered, { backgroundColor: theme.colors.background }]}>
+                <Text variant="bodyLarge">Expense not found</Text>
+                <Button onPress={refetch} style={{ marginTop: spacing.md }}>Retry</Button>
+            </View>
+        );
+    }
+
+    const totalAmount = parseFloat(expense.amount);
+    const emoji = CATEGORY_ICONS[expense.category] || '📦';
+
+    return (
+        <ScrollView
+            style={[styles.container, { backgroundColor: theme.colors.background }]}
+            contentContainerStyle={styles.content}
+        >
+            {/* Header Card */}
+            <Card style={styles.headerCard}>
+                <Card.Content style={styles.headerContent}>
+                    <Text style={styles.emoji}>{emoji}</Text>
+                    <Text variant="headlineMedium" style={styles.description}>
+                        {expense.description}
+                    </Text>
+                    <Text
+                        variant="displaySmall"
+                        style={[styles.amount, { color: theme.colors.primary }]}
+                    >
+                        {expense.currency} {totalAmount.toFixed(2)}
+                    </Text>
+                    <Text
+                        variant="bodyMedium"
+                        style={{ color: theme.colors.onSurfaceVariant, marginTop: 4 }}
+                    >
+                        {format(new Date(expense.date), 'EEEE, MMMM d, yyyy')}
+                    </Text>
+                </Card.Content>
+            </Card>
+
+            {/* Details */}
+            <Card style={styles.card}>
+                <Card.Content>
+                    <Text variant="titleMedium" style={styles.sectionTitle}>Details</Text>
+                    <Divider style={styles.divider} />
+
+                    <View style={styles.detailRow}>
+                        <Text variant="bodyMedium" style={{ color: theme.colors.onSurfaceVariant }}>
+                            Paid by
+                        </Text>
+                        <View style={styles.personRow}>
+                            <Avatar.Text
+                                size={24}
+                                label={(expense.payer?.name || 'U').charAt(0).toUpperCase()}
+                                style={{ backgroundColor: theme.colors.primaryContainer }}
+                            />
+                            <Text variant="bodyMedium" style={{ marginLeft: 8, fontWeight: '600' }}>
+                                {expense.payer?.name || 'Unknown'}
+                            </Text>
+                        </View>
+                    </View>
+
+                    <View style={styles.detailRow}>
+                        <Text variant="bodyMedium" style={{ color: theme.colors.onSurfaceVariant }}>
+                            Category
+                        </Text>
+                        <Chip compact>{expense.category || 'other'}</Chip>
+                    </View>
+
+                    <View style={styles.detailRow}>
+                        <Text variant="bodyMedium" style={{ color: theme.colors.onSurfaceVariant }}>
+                            Split type
+                        </Text>
+                        <Chip compact icon="call-split">{expense.splitType}</Chip>
+                    </View>
+
+                    {expense.notes && (
+                        <View style={[styles.detailRow, { flexDirection: 'column', alignItems: 'flex-start' }]}>
+                            <Text variant="bodyMedium" style={{ color: theme.colors.onSurfaceVariant, marginBottom: 4 }}>
+                                Notes
+                            </Text>
+                            <Text variant="bodyMedium">{expense.notes}</Text>
+                        </View>
+                    )}
+                </Card.Content>
+            </Card>
+
+            {/* Splits */}
+            {expense.splits && expense.splits.length > 0 && (
+                <Card style={styles.card}>
+                    <Card.Content>
+                        <Text variant="titleMedium" style={styles.sectionTitle}>Split Breakdown</Text>
+                        <Divider style={styles.divider} />
+                        {expense.splits.map((split: any, index: number) => {
+                            const splitAmt = parseFloat(split.amount);
+                            const pct = ((splitAmt / totalAmount) * 100).toFixed(0);
+                            return (
+                                <View key={index} style={styles.splitRow}>
+                                    <View style={styles.personRow}>
+                                        <Avatar.Text
+                                            size={32}
+                                            label={(split.user?.name || 'U').charAt(0).toUpperCase()}
+                                            style={{ backgroundColor: theme.colors.secondaryContainer }}
+                                        />
+                                        <Text variant="bodyMedium" style={{ marginLeft: 8 }}>
+                                            {split.user?.name || 'Unknown'}
+                                        </Text>
+                                    </View>
+                                    <View style={{ alignItems: 'flex-end' }}>
+                                        <Text variant="bodyMedium" style={{ fontWeight: '600' }}>
+                                            {expense.currency} {splitAmt.toFixed(2)}
+                                        </Text>
+                                        <Text variant="bodySmall" style={{ color: theme.colors.onSurfaceVariant }}>
+                                            {pct}%
+                                        </Text>
+                                    </View>
+                                </View>
+                            );
+                        })}
+                    </Card.Content>
+                </Card>
+            )}
+
+            {/* Comments */}
+            {expense.comments && expense.comments.length > 0 && (
+                <Card style={styles.card}>
+                    <Card.Content>
+                        <Text variant="titleMedium" style={styles.sectionTitle}>
+                            Comments ({expense.comments.length})
+                        </Text>
+                        <Divider style={styles.divider} />
+                        {expense.comments.map((comment: any, index: number) => (
+                            <View key={index} style={styles.commentRow}>
+                                <Avatar.Text
+                                    size={28}
+                                    label={(comment.user?.name || 'U').charAt(0).toUpperCase()}
+                                    style={{ backgroundColor: theme.colors.tertiaryContainer }}
+                                />
+                                <View style={{ marginLeft: 8, flex: 1 }}>
+                                    <Text variant="labelMedium" style={{ fontWeight: '600' }}>
+                                        {comment.user?.name}
+                                    </Text>
+                                    <Text variant="bodySmall">{comment.comment}</Text>
+                                    <Text variant="bodySmall" style={{ color: theme.colors.onSurfaceVariant }}>
+                                        {format(new Date(comment.createdAt), 'MMM d, h:mm a')}
+                                    </Text>
+                                </View>
+                            </View>
+                        ))}
+                    </Card.Content>
+                </Card>
+            )}
+
+            <Snackbar
+                visible={!!snackbar}
+                onDismiss={() => setSnackbar('')}
+                duration={3000}
+            >
+                {snackbar}
+            </Snackbar>
+        </ScrollView>
+    );
+};
+
+const styles = StyleSheet.create({
+    container: { flex: 1 },
+    centered: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+    content: { padding: spacing.md, paddingBottom: spacing.xl * 2 },
+    headerCard: { marginBottom: spacing.md },
+    headerContent: { alignItems: 'center', paddingVertical: spacing.lg },
+    emoji: { fontSize: 48, marginBottom: spacing.sm },
+    description: { textAlign: 'center', fontWeight: 'bold' },
+    amount: { fontWeight: 'bold', marginTop: spacing.sm },
+    card: { marginBottom: spacing.md },
+    sectionTitle: { fontWeight: 'bold', marginBottom: spacing.sm },
+    divider: { marginBottom: spacing.md },
+    detailRow: {
+        flexDirection: 'row',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        marginBottom: spacing.md,
+    },
+    personRow: { flexDirection: 'row', alignItems: 'center' },
+    splitRow: {
+        flexDirection: 'row',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        paddingVertical: spacing.sm,
+        borderBottomWidth: StyleSheet.hairlineWidth,
+        borderBottomColor: '#e0e0e0',
+    },
+    commentRow: {
+        flexDirection: 'row',
+        alignItems: 'flex-start',
+        marginBottom: spacing.md,
+    },
+});

--- a/frontend/src/screens/groups/GroupDetailScreen.tsx
+++ b/frontend/src/screens/groups/GroupDetailScreen.tsx
@@ -7,8 +7,12 @@ import { spacing } from '@theme';
 import { format } from 'date-fns';
 
 export const GroupDetailScreen = ({ navigation, route }: any) => {
-    const { groupId } = route.params;
+    const { groupId, groupName } = route.params;
     const theme = useTheme();
+
+    React.useLayoutEffect(() => {
+        navigation.setOptions({ title: groupName || 'Group' });
+    }, [navigation, groupName]);
 
     const { data: groupData, isLoading: groupLoading, refetch: refetchGroup } = useGetGroupQuery(groupId);
     const { data: balancesData, isLoading: balancesLoading, refetch: refetchBalances } = useGetGroupBalancesQuery(groupId);
@@ -97,17 +101,31 @@ export const GroupDetailScreen = ({ navigation, route }: any) => {
                 <View style={styles.section}>
                     <View style={styles.sectionHeader}>
                         <Text variant="titleLarge">Expenses</Text>
-                        <Button
-                            onPress={() => navigation.navigate('AddExpense', { groupId })}
-                            icon="plus"
-                        >
-                            Add
-                        </Button>
+                        <View style={{ flexDirection: 'row', gap: 8 }}>
+                            <Button
+                                onPress={() => navigation.navigate('Balances', { groupId })}
+                                icon="scale-balance"
+                                compact
+                            >
+                                Balances
+                            </Button>
+                            <Button
+                                onPress={() => navigation.navigate('AddExpense', { groupId })}
+                                icon="plus"
+                                compact
+                            >
+                                Add
+                            </Button>
+                        </View>
                     </View>
 
                     {expensesData?.expenses && expensesData.expenses.length > 0 ? (
                         expensesData.expenses.map((expense: any) => (
-                            <Card key={expense.id} style={styles.expenseCard}>
+                            <Card
+                                key={expense.id}
+                                style={styles.expenseCard}
+                                onPress={() => navigation.navigate('ExpenseDetail', { expenseId: expense.id })}
+                            >
                                 <Card.Content>
                                     <View style={styles.expenseRow}>
                                         <View style={{ flex: 1 }}>

--- a/frontend/src/screens/settlements/BalancesScreen.tsx
+++ b/frontend/src/screens/settlements/BalancesScreen.tsx
@@ -1,0 +1,297 @@
+import React, { useState } from 'react';
+import {
+    View,
+    StyleSheet,
+    ScrollView,
+    RefreshControl,
+} from 'react-native';
+import {
+    Text,
+    Card,
+    Button,
+    useTheme,
+    ActivityIndicator,
+    Divider,
+    Avatar,
+    FAB,
+    SegmentedButtons,
+} from 'react-native-paper';
+import { useGetGroupBalancesQuery, useGetGroupsQuery } from '@api/groupsApi';
+import { useGetSettlementsQuery } from '@api/settlementsApi';
+import { useAppSelector } from '@hooks/redux';
+import { spacing } from '@theme';
+import { format } from 'date-fns';
+import { EmptyState } from '@components/EmptyState';
+import { LoadingList } from '@components/LoadingSkeleton';
+
+export const BalancesScreen = ({ navigation, route }: any) => {
+    const { groupId } = route.params || {};
+    const theme = useTheme();
+    const currentUser = useAppSelector((state: any) => state.auth.user);
+    const [view, setView] = useState<'balances' | 'history'>('balances');
+    const [refreshing, setRefreshing] = useState(false);
+
+    const {
+        data: balancesData,
+        isLoading: balancesLoading,
+        refetch: refetchBalances,
+    } = useGetGroupBalancesQuery(groupId, { skip: !groupId });
+
+    const {
+        data: settlementsData,
+        isLoading: settlementsLoading,
+        refetch: refetchSettlements,
+    } = useGetSettlementsQuery({ groupId, limit: 50 });
+
+    const onRefresh = async () => {
+        setRefreshing(true);
+        await Promise.all([refetchBalances(), refetchSettlements()]);
+        setRefreshing(false);
+    };
+
+    const isLoading = balancesLoading || settlementsLoading;
+
+    if (isLoading && !refreshing) {
+        return (
+            <View style={[styles.container, { backgroundColor: theme.colors.background }]}>
+                <LoadingList count={4} />
+            </View>
+        );
+    }
+
+    const balances = balancesData?.balances || [];
+    const settlements = settlementsData?.settlements || [];
+
+    // Separate into "you owe" and "owed to you"
+    const myBalances = balances.filter((b: any) => b.userId === currentUser?.id);
+    const positiveBalances = balances.filter((b: any) => parseFloat(b.balance) > 0);
+    const negativeBalances = balances.filter((b: any) => parseFloat(b.balance) < 0);
+
+    return (
+        <View style={[styles.container, { backgroundColor: theme.colors.background }]}>
+            <SegmentedButtons
+                value={view}
+                onValueChange={(v) => setView(v as any)}
+                buttons={[
+                    { value: 'balances', label: 'Balances', icon: 'scale-balance' },
+                    { value: 'history', label: 'History', icon: 'history' },
+                ]}
+                style={styles.segmented}
+            />
+
+            <ScrollView
+                refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />}
+                contentContainerStyle={styles.scrollContent}
+            >
+                {view === 'balances' ? (
+                    <>
+                        {/* Owed to others */}
+                        {negativeBalances.length > 0 && (
+                            <View style={styles.section}>
+                                <Text
+                                    variant="titleSmall"
+                                    style={[styles.sectionLabel, { color: theme.colors.error }]}
+                                >
+                                    YOU OWE
+                                </Text>
+                                {negativeBalances.map((balance: any, i: number) => (
+                                    <Card key={i} style={styles.balanceCard}>
+                                        <Card.Content style={styles.balanceRow}>
+                                            <View style={styles.personRow}>
+                                                <Avatar.Text
+                                                    size={40}
+                                                    label={(balance.userName || 'U').charAt(0).toUpperCase()}
+                                                    style={{ backgroundColor: theme.colors.errorContainer }}
+                                                />
+                                                <View style={{ marginLeft: 12 }}>
+                                                    <Text variant="titleMedium">{balance.userName}</Text>
+                                                    <Text
+                                                        variant="bodySmall"
+                                                        style={{ color: theme.colors.onSurfaceVariant }}
+                                                    >
+                                                        you owe them
+                                                    </Text>
+                                                </View>
+                                            </View>
+                                            <View style={{ alignItems: 'flex-end' }}>
+                                                <Text
+                                                    variant="titleMedium"
+                                                    style={{ color: theme.colors.error, fontWeight: 'bold' }}
+                                                >
+                                                    ${Math.abs(parseFloat(balance.balance)).toFixed(2)}
+                                                </Text>
+                                                <Button
+                                                    mode="contained-tonal"
+                                                    compact
+                                                    onPress={() =>
+                                                        navigation.navigate('SettleUp', {
+                                                            groupId,
+                                                            payeeId: balance.userId,
+                                                            payeeName: balance.userName,
+                                                            amount: Math.abs(parseFloat(balance.balance)),
+                                                        })
+                                                    }
+                                                    style={{ marginTop: 4 }}
+                                                >
+                                                    Settle
+                                                </Button>
+                                            </View>
+                                        </Card.Content>
+                                    </Card>
+                                ))}
+                            </View>
+                        )}
+
+                        {/* Owed by others */}
+                        {positiveBalances.length > 0 && (
+                            <View style={styles.section}>
+                                <Text
+                                    variant="titleSmall"
+                                    style={[styles.sectionLabel, { color: theme.colors.primary }]}
+                                >
+                                    OWED TO YOU
+                                </Text>
+                                {positiveBalances.map((balance: any, i: number) => (
+                                    <Card key={i} style={styles.balanceCard}>
+                                        <Card.Content style={styles.balanceRow}>
+                                            <View style={styles.personRow}>
+                                                <Avatar.Text
+                                                    size={40}
+                                                    label={(balance.userName || 'U').charAt(0).toUpperCase()}
+                                                    style={{ backgroundColor: theme.colors.primaryContainer }}
+                                                />
+                                                <View style={{ marginLeft: 12 }}>
+                                                    <Text variant="titleMedium">{balance.userName}</Text>
+                                                    <Text
+                                                        variant="bodySmall"
+                                                        style={{ color: theme.colors.onSurfaceVariant }}
+                                                    >
+                                                        owes you
+                                                    </Text>
+                                                </View>
+                                            </View>
+                                            <Text
+                                                variant="titleMedium"
+                                                style={{ color: theme.colors.primary, fontWeight: 'bold' }}
+                                            >
+                                                ${parseFloat(balance.balance).toFixed(2)}
+                                            </Text>
+                                        </Card.Content>
+                                    </Card>
+                                ))}
+                            </View>
+                        )}
+
+                        {balances.length === 0 && (
+                            <EmptyState
+                                icon="check-circle-outline"
+                                title="All settled up!"
+                                description="No outstanding balances in this group."
+                            />
+                        )}
+                    </>
+                ) : (
+                    <>
+                        <Text variant="titleSmall" style={styles.sectionLabel}>
+                            SETTLEMENT HISTORY
+                        </Text>
+                        {settlements.length > 0 ? (
+                            settlements.map((s: any, i: number) => (
+                                <Card key={i} style={styles.balanceCard}>
+                                    <Card.Content>
+                                        <View style={styles.balanceRow}>
+                                            <View style={styles.personRow}>
+                                                <Avatar.Icon
+                                                    size={36}
+                                                    icon="bank-transfer"
+                                                    style={{ backgroundColor: theme.colors.secondaryContainer }}
+                                                />
+                                                <View style={{ marginLeft: 10 }}>
+                                                    <Text variant="bodyMedium">
+                                                        <Text style={{ fontWeight: '600' }}>{s.payer?.name}</Text>
+                                                        {' → '}
+                                                        <Text style={{ fontWeight: '600' }}>{s.payee?.name}</Text>
+                                                    </Text>
+                                                    <Text
+                                                        variant="bodySmall"
+                                                        style={{ color: theme.colors.onSurfaceVariant }}
+                                                    >
+                                                        {format(new Date(s.date || s.createdAt), 'MMM d, yyyy')}
+                                                    </Text>
+                                                </View>
+                                            </View>
+                                            <Text variant="titleMedium" style={{ fontWeight: 'bold' }}>
+                                                ${parseFloat(s.amount).toFixed(2)}
+                                            </Text>
+                                        </View>
+                                        {s.notes && (
+                                            <Text
+                                                variant="bodySmall"
+                                                style={{
+                                                    color: theme.colors.onSurfaceVariant,
+                                                    marginTop: 4,
+                                                    marginLeft: 46,
+                                                }}
+                                            >
+                                                {s.notes}
+                                            </Text>
+                                        )}
+                                    </Card.Content>
+                                </Card>
+                            ))
+                        ) : (
+                            <EmptyState
+                                icon="history"
+                                title="No settlements yet"
+                                description="Settlements will appear here once recorded."
+                            />
+                        )}
+                    </>
+                )}
+            </ScrollView>
+
+            {view === 'balances' && negativeBalances.length > 0 && (
+                <FAB
+                    icon="handshake"
+                    label="Settle Up"
+                    style={[styles.fab, { backgroundColor: theme.colors.primary }]}
+                    onPress={() =>
+                        navigation.navigate('SettleUp', {
+                            groupId,
+                            amount: Math.abs(parseFloat(negativeBalances[0]?.balance || '0')),
+                            payeeId: negativeBalances[0]?.userId,
+                            payeeName: negativeBalances[0]?.userName,
+                        })
+                    }
+                />
+            )}
+        </View>
+    );
+};
+
+const styles = StyleSheet.create({
+    container: { flex: 1 },
+    segmented: { margin: spacing.md },
+    scrollContent: { paddingBottom: 100 },
+    section: { marginBottom: spacing.md },
+    sectionLabel: {
+        fontWeight: 'bold',
+        letterSpacing: 1,
+        marginHorizontal: spacing.md,
+        marginBottom: spacing.sm,
+        marginTop: spacing.sm,
+    },
+    balanceCard: { marginHorizontal: spacing.md, marginBottom: spacing.sm },
+    balanceRow: {
+        flexDirection: 'row',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+    },
+    personRow: { flexDirection: 'row', alignItems: 'center' },
+    fab: {
+        position: 'absolute',
+        margin: 16,
+        right: 0,
+        bottom: 0,
+    },
+});

--- a/frontend/src/screens/settlements/SettleUpScreen.tsx
+++ b/frontend/src/screens/settlements/SettleUpScreen.tsx
@@ -1,0 +1,224 @@
+import React, { useState } from 'react';
+import {
+    View,
+    StyleSheet,
+    ScrollView,
+    KeyboardAvoidingView,
+    Platform,
+} from 'react-native';
+import {
+    Text,
+    TextInput,
+    Button,
+    useTheme,
+    Card,
+    Avatar,
+    Snackbar,
+    SegmentedButtons,
+    Divider,
+} from 'react-native-paper';
+import { useCreateSettlementMutation } from '@api/settlementsApi';
+import { useAppSelector } from '@hooks/redux';
+import { spacing } from '@theme';
+
+const PAYMENT_METHODS = [
+    { value: 'cash', label: 'Cash', icon: 'cash' },
+    { value: 'bank_transfer', label: 'Bank', icon: 'bank' },
+    { value: 'upi', label: 'UPI', icon: 'cellphone' },
+    { value: 'other', label: 'Other', icon: 'dots-horizontal' },
+];
+
+export const SettleUpScreen = ({ navigation, route }: any) => {
+    const { groupId, payeeId, payeeName, amount: suggestedAmount } = route.params || {};
+    const theme = useTheme();
+    const currentUser = useAppSelector((state: any) => state.auth.user);
+
+    const [amount, setAmount] = useState(suggestedAmount?.toFixed(2) || '');
+    const [paymentMethod, setPaymentMethod] = useState('cash');
+    const [notes, setNotes] = useState('');
+    const [error, setError] = useState('');
+    const [success, setSuccess] = useState(false);
+
+    const [createSettlement, { isLoading }] = useCreateSettlementMutation();
+
+    const handleSettle = async () => {
+        const numAmount = parseFloat(amount);
+        if (!numAmount || numAmount <= 0) {
+            setError('Please enter a valid amount');
+            return;
+        }
+        if (!payeeId) {
+            setError('Payee not specified');
+            return;
+        }
+
+        try {
+            setError('');
+            await createSettlement({
+                groupId,
+                payerId: currentUser?.id,
+                payeeId,
+                amount: numAmount,
+                currency: 'USD',
+                paymentMethod,
+                notes: notes.trim() || undefined,
+            }).unwrap();
+
+            setSuccess(true);
+            setTimeout(() => navigation.goBack(), 1500);
+        } catch (err: any) {
+            setError(err?.data?.error?.message || 'Failed to record settlement');
+        }
+    };
+
+    return (
+        <KeyboardAvoidingView
+            behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+            style={[styles.container, { backgroundColor: theme.colors.background }]}
+        >
+            <ScrollView contentContainerStyle={styles.content} keyboardShouldPersistTaps="handled">
+
+                {/* Settlement Summary Card */}
+                <Card style={styles.summaryCard}>
+                    <Card.Content style={styles.summaryContent}>
+                        <View style={styles.avatarRow}>
+                            <View style={styles.avatarItem}>
+                                <Avatar.Text
+                                    size={52}
+                                    label={(currentUser?.name || 'Y').charAt(0).toUpperCase()}
+                                    style={{ backgroundColor: theme.colors.primaryContainer }}
+                                />
+                                <Text variant="labelMedium" style={{ marginTop: 4 }}>
+                                    {currentUser?.name || 'You'}
+                                </Text>
+                            </View>
+
+                            <View style={styles.arrowContainer}>
+                                <Text style={[styles.arrow, { color: theme.colors.primary }]}>→</Text>
+                                <Text
+                                    variant="bodySmall"
+                                    style={{ color: theme.colors.onSurfaceVariant, textAlign: 'center' }}
+                                >
+                                    paying
+                                </Text>
+                            </View>
+
+                            <View style={styles.avatarItem}>
+                                <Avatar.Text
+                                    size={52}
+                                    label={(payeeName || 'P').charAt(0).toUpperCase()}
+                                    style={{ backgroundColor: theme.colors.secondaryContainer }}
+                                />
+                                <Text variant="labelMedium" style={{ marginTop: 4 }}>
+                                    {payeeName || 'Payee'}
+                                </Text>
+                            </View>
+                        </View>
+                    </Card.Content>
+                </Card>
+
+                {/* Amount */}
+                <Text variant="titleMedium" style={styles.label}>Amount</Text>
+                <TextInput
+                    mode="outlined"
+                    label="Amount"
+                    value={amount}
+                    onChangeText={setAmount}
+                    keyboardType="decimal-pad"
+                    left={<TextInput.Affix text="$" />}
+                    style={styles.input}
+                    error={!!error && !parseFloat(amount)}
+                />
+
+                {suggestedAmount && (
+                    <Button
+                        mode="text"
+                        compact
+                        onPress={() => setAmount(suggestedAmount.toFixed(2))}
+                        style={{ alignSelf: 'flex-start', marginTop: -8 }}
+                    >
+                        Use full amount: ${suggestedAmount.toFixed(2)}
+                    </Button>
+                )}
+
+                <Divider style={styles.divider} />
+
+                {/* Payment Method */}
+                <Text variant="titleMedium" style={styles.label}>Payment Method</Text>
+                <SegmentedButtons
+                    value={paymentMethod}
+                    onValueChange={setPaymentMethod}
+                    buttons={PAYMENT_METHODS}
+                    style={styles.segmented}
+                />
+
+                <Divider style={styles.divider} />
+
+                {/* Notes */}
+                <Text variant="titleMedium" style={styles.label}>Notes (optional)</Text>
+                <TextInput
+                    mode="outlined"
+                    label="Add a note"
+                    value={notes}
+                    onChangeText={setNotes}
+                    multiline
+                    numberOfLines={2}
+                    style={styles.input}
+                />
+
+                {error ? (
+                    <Text style={[styles.errorText, { color: theme.colors.error }]}>{error}</Text>
+                ) : null}
+
+                <Button
+                    mode="contained"
+                    onPress={handleSettle}
+                    loading={isLoading}
+                    disabled={isLoading}
+                    style={styles.submitButton}
+                    icon="check"
+                >
+                    {isLoading ? 'Recording...' : 'Record Settlement'}
+                </Button>
+
+                <Button
+                    mode="text"
+                    onPress={() => navigation.goBack()}
+                    style={{ marginTop: spacing.sm }}
+                >
+                    Cancel
+                </Button>
+            </ScrollView>
+
+            <Snackbar
+                visible={success}
+                onDismiss={() => setSuccess(false)}
+                duration={1500}
+            >
+                ✅ Settlement recorded!
+            </Snackbar>
+        </KeyboardAvoidingView>
+    );
+};
+
+const styles = StyleSheet.create({
+    container: { flex: 1 },
+    content: { padding: spacing.lg, paddingBottom: spacing.xl * 2 },
+    summaryCard: { marginBottom: spacing.lg },
+    summaryContent: { alignItems: 'center', paddingVertical: spacing.md },
+    avatarRow: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        justifyContent: 'space-around',
+        width: '100%',
+    },
+    avatarItem: { alignItems: 'center' },
+    arrowContainer: { alignItems: 'center' },
+    arrow: { fontSize: 32, fontWeight: 'bold' },
+    label: { marginBottom: spacing.sm, fontWeight: '600' },
+    input: { marginBottom: spacing.sm },
+    segmented: { marginBottom: spacing.sm },
+    divider: { marginVertical: spacing.md },
+    errorText: { marginBottom: spacing.sm, fontSize: 13 },
+    submitButton: { marginTop: spacing.md },
+});


### PR DESCRIPTION
## Summary
Fixes the crash reported in #2 where tapping **Edit** in ExpenseDetailScreen caused a runtime navigation error because the EditExpense route was not registered.

## Changes
- **New file**: rontend/src/screens/expenses/EditExpenseScreen.tsx
  - Pre-populates all fields from useGetExpenseQuery
  - Uses useUpdateExpenseMutation to save changes
  - Includes member checkboxes, per-member split inputs, real-time amount preview, and sum validation (mirrors AddExpenseScreen)
  - Shows loading spinner while fetching existing expense data
- **Modified**: rontend/src/navigation/GroupsNavigator.tsx
  - Imported EditExpenseScreen
  - Registered EditExpense as a modal route in the stack

## Testing
1. Open any group with an existing expense
2. Tap the expense ? ExpenseDetailScreen opens
3. Tap ? ? **Edit** ? EditExpenseScreen opens pre-filled ?
4. Modify fields ? tap **Save Changes** ? expense updates and screen closes ?

closes #2