### PR TITLE
[#5] fix: pass groupName param in GroupListScreen navigation to GroupDetail

### DIFF
--- a/frontend/src/screens/groups/GroupListScreen.tsx
+++ b/frontend/src/screens/groups/GroupListScreen.tsx
@@ -53,7 +53,7 @@ export const GroupListScreen = ({ navigation }: any) => {
                             key={group.id}
                             style={styles.groupCard}
                             onPress={() =>
-                                navigation.navigate('GroupDetail', { groupId: group.id })
+                                navigation.navigate('GroupDetail', { groupId: group.id, groupName: group.name })
                             }
                         >
                             <Card.Content>


### PR DESCRIPTION
## Summary
Fixes #5 - the `GroupDetailScreen` header was always showing the generic fallback title "Group" because `GroupListScreen` was not passing the `groupName` param when navigating.

## Change
- **Modified**: `frontend/src/screens/groups/GroupListScreen.tsx` (line 56)
  - Added `groupName: group.name` to the `navigation.navigate('GroupDetail', ...)` call

## Testing
1. Navigate to Groups tab
2. Tap any group card
3. Header now shows the actual group name ?

closes #5