### PR TITLE
[#6] fix: wire dark mode toggle in ProfileScreen to Redux setTheme

### DIFF
--- a/frontend/src/screens/profile/ProfileScreen.tsx
+++ b/frontend/src/screens/profile/ProfileScreen.tsx
@@ -17,6 +17,7 @@ import {
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
 import { useAppDispatch, useAppSelector } from '@hooks/redux';
 import { logout } from '@store/slices/authSlice';
+import { setTheme } from '@store/slices/uiSlice';
 import { useGetSupportedCurrenciesQuery } from '@api/currencyApi';
 import { spacing } from '@theme';
 
@@ -26,10 +27,11 @@ export const ProfileScreen = () => {
     const theme = useTheme();
     const dispatch = useAppDispatch();
     const user = useAppSelector((state) => state.auth.user);
+    const currentTheme = useAppSelector((state: any) => state.ui.theme);
+    const isDarkMode = currentTheme === 'dark';
 
     const [currencyDialogVisible, setCurrencyDialogVisible] = useState(false);
     const [selectedCurrency, setSelectedCurrency] = useState('USD');
-    const [darkMode, setDarkMode] = useState(false);
     const [snackbar, setSnackbar] = useState('');
 
     const { data: currenciesData } = useGetSupportedCurrenciesQuery();
@@ -109,8 +111,11 @@ export const ProfileScreen = () => {
                         left={(props) => <List.Icon {...props} icon="theme-light-dark" />}
                         right={() => (
                             <Switch
-                                value={darkMode}
-                                onValueChange={setDarkMode}
+                                value={isDarkMode}
+                                onValueChange={(val) => {
+                                    dispatch(setTheme(val ? 'dark' : 'light'));
+                                    setSnackbar(`Switched to ${val ? 'dark' : 'light'} mode`);
+                                }}
                             />
                         )}
                     />


### PR DESCRIPTION
## Summary
Fixes #6 - the Dark Mode toggle in `ProfileScreen` was using isolated local state (`useState`) and had no effect on the app theme.

## Root Cause
`uiSlice` already had a `setTheme` action and `App.tsx` already read `state.ui.theme` to switch `PaperProvider` theme - the only missing piece was `ProfileScreen` dispatching to Redux instead of updating local state.

## Changes
- **Modified**: `frontend/src/screens/profile/ProfileScreen.tsx`
  - Removed local `darkMode` state
  - Added `useAppSelector` to read `state.ui.theme`
  - Toggle now dispatches `setTheme('dark' | 'light')` to Redux
  - Shows snackbar confirmation: "Switched to dark/light mode"

## Testing
1. Navigate to Profile tab
2. Toggle **Dark Mode** switch
3. Entire app theme switches immediately ?
4. Toggle back - reverts to light theme ?

closes #6